### PR TITLE
Move SMILES file saving to DanceSaver

### DIFF
--- a/dance.py
+++ b/dance.py
@@ -134,10 +134,11 @@ def configure_logging(loglevel: str):
 
 def run_filter(args):
     """Filters molecules from the database."""
-    dfilter = dancefilter.DanceFilter(args["mol2dirs"], args["output_mols"])
+    dfilter = dancefilter.DanceFilter(args["mol2dirs"])
     dfilter.run()
     mols, properties = dfilter.get_data()
-    dsaver = dancesaver.DanceSaver(mols, properties, args["output_tri_n_data"],
+    dsaver = dancesaver.DanceSaver(mols, properties, args["output_mols"],
+                                   args["output_tri_n_data"],
                                    args["output_tri_n_bonds"])
     dsaver.run()
 

--- a/dancelib/dancefilter.py
+++ b/dancelib/dancefilter.py
@@ -12,7 +12,7 @@ from dancelib import dancerunbase
 # Constants
 #
 
-# Trivalent Nitrogen checker - instead of repeatedly constructing this class
+# Trivalent Nitrogen checker - instead of repeatedly constructing this object
 IS_TRI_N = oechem.OEIsInvertibleNitrogen()
 
 # Object for calculating AM1 charges - instead of reconstructing it everywhere
@@ -29,14 +29,11 @@ class DanceFilter(dancerunbase.DanceRunBase):
         - the molecules and their properties will be available via the
           get_data() method - the molecules returned will be sorted by Wiberg
           bond order and only have one trivalent nitrogen
-        - a SMILES file with the molecules will have been written at the
-          location specified upon initialization
     Note that the class is only meant to be run once, and attempting to call
     run() again will result in a RuntimeError.
 
     Attributes:
         _mol2dirs: list of names of directories with mol2 files
-        _output: the name of the output file to which to write the molecules
         _mols: a list storing the molecules the class is currently handling
         _properties: a list storing properties of the molecules (see
                      danceprops.py for more info)
@@ -46,10 +43,9 @@ class DanceFilter(dancerunbase.DanceRunBase):
     # Public
     #
 
-    def __init__(self, mol2dirs: [str], output: str):
+    def __init__(self, mol2dirs: [str]):
         super().__init__()
         self._mol2dirs = mol2dirs
-        self._output = output
         self._mols = []
         self._properties = []
 
@@ -60,7 +56,6 @@ class DanceFilter(dancerunbase.DanceRunBase):
         self._filter_tri_n()
         self._apply_properties()
         self._sort_by_wiberg()
-        self._write_to_smiles_file()
         logging.info("FINISHED FILTERING")
 
     def get_data(self) -> ([oechem.OEMol], [danceprops.DanceProperties]):
@@ -105,15 +100,6 @@ class DanceFilter(dancerunbase.DanceRunBase):
             key=
             lambda m: danceprops.get_dance_property(m, self._properties).tri_n_bond_order
         )
-
-    def _write_to_smiles_file(self):
-        """Writes the molecules to the SMILES file"""
-        logging.info(f"Writing molecules to SMILES file {self._output}")
-        ostream = oechem.oemolostream(self._output)
-        ostream.SetFormat(oechem.OEFormat_USM)
-        for mol in self._mols:
-            oechem.OEWriteMolecule(ostream, mol)
-        ostream.close()
 
     #
     # Private (utility)

--- a/dancelib/dancesaver.py
+++ b/dancelib/dancesaver.py
@@ -7,7 +7,7 @@ from dancelib import dancerunbase
 
 
 class DanceSaver(dancerunbase.DanceRunBase):
-    """Saves molecule data from DanceFilter.
+    """Saves molecule data from DanceFilter as SMILES strings and in CSV's.
 
     Molecules passed in should have the danceprops.DANCE_PROPS_KEY data set;
     failure to have this results in undefined behavior.
@@ -20,6 +20,7 @@ class DanceSaver(dancerunbase.DanceRunBase):
         _mols: the molecules which are being saved
         _properties: a list storing properties of the molecules (see
                      danceprops.py for more info)
+        _output_mols: SMILES file for SMILES strings of molecules
         _output_tri_n_data: csv file for data about trivalent nitrogens
         _output_tri_n_bonds: csv file for data about trivalent nitrogen bonds
     """
@@ -29,11 +30,12 @@ class DanceSaver(dancerunbase.DanceRunBase):
     #
 
     def __init__(self, mols: [oechem.OEMol],
-                 properties: [danceprops.DanceProperties],
+                 properties: [danceprops.DanceProperties], output_mols: str,
                  output_tri_n_data: str, output_tri_n_bonds: str):
         super().__init__()
         self._mols = mols
         self._properties = properties
+        self._output_mols = output_mols
         self._output_tri_n_data = output_tri_n_data
         self._output_tri_n_bonds = output_tri_n_bonds
 
@@ -41,12 +43,22 @@ class DanceSaver(dancerunbase.DanceRunBase):
         """Perform all saving actions"""
         super().check_run_fatal()
         logging.info("STARTING SAVE")
+        self._write_to_smiles_file()
         self._write_to_csv()
         logging.info("FINISHED SAVE")
 
     #
     # Private
     #
+
+    def _write_to_smiles_file(self):
+        """Writes the molecules to the SMILES file"""
+        logging.info(f"Writing molecules to SMILES file {self._output_mols}")
+        ostream = oechem.oemolostream(self._output_mols)
+        ostream.SetFormat(oechem.OEFormat_USM)
+        for mol in self._mols:
+            oechem.OEWriteMolecule(ostream, mol)
+        ostream.close()
 
     def _write_to_csv(self):
         """Writes the data about trivalent nitrogens and their bonds to CSVs"""


### PR DESCRIPTION
Before, the SMILES file with trivalent nitrogen molecules was being
saved in DanceFilter, which did not make much sense because DanceSaver
was intended to be used for saving files.